### PR TITLE
add "dishwasher" appliance child of "dish washer"

### DIFF
--- a/nilm_metadata/central_metadata/appliance_types/wet.yaml
+++ b/nilm_metadata/central_metadata/appliance_types/wet.yaml
@@ -79,6 +79,9 @@ dish washer:
         source: empirical from publication
         related_documents: *Stamminger2008
 
+dishwasher:
+  parent: dish washer
+
 waste disposal unit:
   parent: wet appliance
 


### PR DESCRIPTION
This is essentially an alternate spelling, since "dishwasher" is found in the GREEND database, and so fails the sanity check without the appliance included here.

Closes https://github.com/nilmtk/nilmtk/issues/618